### PR TITLE
Add onClick support for next.js Link component

### DIFF
--- a/src/next.tsx
+++ b/src/next.tsx
@@ -29,6 +29,7 @@ export function Link({
     children,
     replace,
     scroll,
+    onClick,
     ...rest
 }: Parameters<typeof NextLink>[0]) {
     const router = useRouter();
@@ -38,6 +39,7 @@ export function Link({
         <NextLink
             href={href}
             onClick={(e) => {
+                onClick?.(e);
                 if (isModifiedEvent(e)) return;
                 e.preventDefault();
                 startTransition(() => {


### PR DESCRIPTION
This PR addresses the issue #16.

This pull request adds support for the `onClick` event handler in the `Link` component of Next.js. Previously, the `onClick` prop was not available in the `Link` component, but with this change, developers can now provide a custom `onClick` function to handle click events on the `Link` component. This enhancement improves the flexibility and functionality of the `Link` component in Next.js.